### PR TITLE
v1.2.0 Fix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,16 @@ _In this template example the top two fields will match with my Content Blocks._
    );
    ```
 
-   If you don't want to use the constant helpers then this may look like:
+   > :raising_hand: You can use the helper method `getUniqueItemName([name=CONFIG.ITEM_NAME])` to generate an Item name with a timestamp. You can provide a name parameter or it will default to the `ITEM_NAME` in your config.
+
+   ```js
+   const response = await cb.createItem(
+     cb.getUniqueItemName(),              //::> Item Name
+     CWBlocks.CONFIG.TEMPLATES.PRODUCT,   //::> Template ID
+   // ...
+   ```
+
+   If you don't want to use the constant helpers then your `createItem()` call may look like:
 
    ```js
    const response = await cb.createItem(
@@ -142,7 +151,7 @@ _In this template example the top two fields will match with my Content Blocks._
    );
    ```
 
-   You can call `createItem()` as many times as you need to create more Items for the same project and Master Template.
+   You can call `createItem()` from a loop or as many times as you need to create more Items for the same Project and Master Template.
 
    > :raising_hand: If you need to create multiple Items from different projects or with different Master Templates then have a look at the `create-advanced.js` file.
 

--- a/config.js
+++ b/config.js
@@ -4,16 +4,27 @@ import 'dotenv/config';
  * CBCWConfig
  * Configuration for Bynder Content Blocks
  * @type {Object}
+ * @property {string} BASE_URL - Base URL for Content Workflow API (default: https://api.gathercontent.com) {@link BASE_URL}
  * @property {Object} AUTH - Authentication foe Content Workflow API {@link AUTH}
  * @property {string} AUTH.EMAIL - Content Workflow Email (.env: EMAIL)
  * @property {string} AUTH.API_KEY - Content Workflow API Key (.env: API_KEY)
  * @property {number} PROJECT_ID - Content Workflow Project ID (.env: PROJECT_ID)
- * @property {Function|string} ITEM_NAME - Generates unique test item name with timestamp (.env: ITEM_NAME) {@link ITEM_NAME}
+ * @property {string} ITEM_NAME - The name of the Item to be created (.env: ITEM_NAME) {@link ITEM_NAME}
  * @property {Object} TEMPLATES - Template IDs used for different content types {@link TEMPLATES}
  * @property {number} TEMPLATES.MASTER - The master template ID (.env: MASTER_TEMPLATE_ID)
  * @property {Object} GROUPS - Group names used for different product types {@link GROUPS}
+ * @method {Function} getUniqueItemName([name]) - Generates a unique name for the Item {@link getUniqueItemName}
+ *
+ * @see {@link https://docs.gathercontent.com/reference/getting-started}
  */
 export const CBCWConfig = {
+  /**
+   * Base URL
+   * @type {string} - Base URL for Content Workflow API (default: https://api.gathercontent.com)
+   * @see {@link https://docs.gathercontent.com/reference/getting-started}
+   */
+  BASE_URL: encodeURI(process.env.BASE_URL ?? 'https://api.gathercontent.com'),
+
   /**
    * Authentication configuration (Default from .env)
    * @type {Object}
@@ -28,16 +39,17 @@ export const CBCWConfig = {
 
   /**
    * Project ID
-   * @type {number}
+   * @type {number} - Project ID for the GatherContent project
    */
   PROJECT_ID: Number(process.env.PROJECT_ID),
 
   /**
-   * Generates a unique test item name with timestamp (uses env: ITEM_NAME)
-   * @returns {string} Test item name with current timestamp
+   * Item name
+   * @type {string} - Name of the test item (env: ITEM_NAME, default: 'Test Item')
+   * Used for creating a new item in the project and in ITEM_NAME_DT to create a unique name
+   * @see {@link ITEM_NAME_DT}
    */
-  ITEM_NAME: (() => `${process.env.ITEM_NAME ?? 'Test Item'} ${new Date().getTime()}`)(),
-  // ITEM_NAME: process.env.ITEM_NAME ?? 'Test Item', // Can uncomment and replace above with a static name
+  ITEM_NAME: process.env.ITEM_NAME ?? 'Test Item',
 
   /**
    * Template IDs used for different content types

--- a/create-advanced.js
+++ b/create-advanced.js
@@ -13,23 +13,24 @@ try {
    * @see {@link CWBlocks.create}
    * @see {@link Item}
    * */
-  // Create template object from template ID
-  const template = await cb.getTemplate(CWBlocks.CONFIG.TEMPLATES.PRODUCT);
+  // Create Template object from any Template ID
+  const template = await cb.getTemplate(3240083); //::> Template ID
   // Create a new Item
   const item = new Item(
-    'The Product Name',                  //::> Item Name
-    CWBlocks.CONFIG.PROJECT_ID,          //::> Project ID
-    template,                            //::> Template object created from the above
-    CWBlocks.CONFIG.GROUPS.PRODUCT_TWO,  //::> Master Template Group Name (Optional)
+    cb.getUniqueItemName('The Product Name'),  //::> Item Name
+    393102,                                    //::> Project ID
+    template,                                  //::> Template object (created above)
+    'Product Two',                             //::> Master Template Group name (Optional)
   );
-  // include the masterTemplateId when getting the content blocks
-  await cb.getContentBlocks(item, 3263673);
+  // Include the Master Template ID when getting the content blocks
+  await cb.getContentBlocks(item, 3263673); //::> Master Template ID
+  // Create the item in Content Workflow
   const outputAdv = await cb.create(item);
 
-  console.log('::| BynderContentBlocks Advanced |::::>', outputAdv);
+  console.log('::BynderContentBlocks::| Advanced Item Created |::>', outputAdv);
 
 } catch (error) {
-  console.error('::| BynderContentBlocks |::ERROR::>', error.message);
+  console.error('::BynderContentBlocks::| ERROR |::>', error);
 }
 
 

--- a/create.js
+++ b/create.js
@@ -11,13 +11,13 @@ try {
    * @see {@link CWBlocks.CONFIG}
    */
   const output = await cb.createItem(
-    CWBlocks.CONFIG.ITEM_NAME,           //::> Item Name
+    cb.getUniqueItemName(),              //::> Item Name
     CWBlocks.CONFIG.TEMPLATES.PRODUCT,   //::> Template ID
     CWBlocks.CONFIG.GROUPS.PRODUCT_ONE,  //::> Master Template Group Name (Optional)
   );
 
-  console.log('::| BynderContentBlocks |::::>', output);
+  console.log('::BynderContentBlocks::| Item Created |::>', output);
 
 } catch (error) {
-  console.error('::| BynderContentBlocks |::ERROR::>', error.message);
+  console.error('::BynderContentBlocks::| ERROR |::>', error);
 }

--- a/lib/cwblocks.js
+++ b/lib/cwblocks.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 import { decode } from 'html-entities';
 import { Item } from './item.js';
 import { CBCWConfig } from '../config.js';
-import 'dotenv/config';
 
 /**
  * CW Class
@@ -16,12 +15,6 @@ export class CWBlocks {
    * @see {@link CBCWConfig}
    */
   static CONFIG = CBCWConfig;
-
-  /**
-   * Base URL for the Content Workflow API
-   * @type {string}
-   */
-  baseURL = process.env.BASE_URL ?? 'https://api.gathercontent.com';
 
   /**
    * Create a new instance of the CW class
@@ -38,13 +31,22 @@ export class CWBlocks {
     const auth64 = Buffer.from(`${email}:${apiKey}`).toString('base64');
 
     this.api = axios.create({
-      baseURL: this.baseURL,
+      baseURL: CWBlocks.CONFIG.BASE_URL,
       headers: {
         Authorization: `Basic ${auth64}`,
         'content-type': 'application/json',
         Accept: 'application/vnd.gathercontent.v2+json',
       },
     });
+  }
+
+  /**
+   * Generates a unique Item name with timestamp
+   * @param {string} [name] - Optional name to use instead of the default CWBlocks.CONFIG.ITEM_NAME
+   * @returns {string} Item name with current timestamp
+   */
+  getUniqueItemName(name) {
+    return `${name ?? CWBlocks.CONFIG.ITEM_NAME} ${new Date().getTime()}`;
   }
 
   /**
@@ -160,9 +162,8 @@ export class CWBlocks {
 
   /**
    * Create a new Item in Content Workflow
-   * @param {Int} projectId The project ID to create the item in
    * @param {Item} item The item to create
-   * @throws Will throw an error if projectId or item is not provided or if item is not an instance of Item
+   * @throws Will throw an error if item is not provided or not an instance of Item
    * @returns {Object} The response data from the API
    */
   async create(item) {
@@ -182,7 +183,6 @@ export class CWBlocks {
       );
     }
 
-    // return {item, response: response.data.data};
     return response.data.data;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bynder-content-blocks",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A Proof of Concept: Content Blocks for Bynder's Content Workflow. Use a master Template to create Content Blocks then create content Items with fields pre-populated with block content.",
   "author": {
     "name": "Will Furphy",


### PR DESCRIPTION
# v1.2.0 Release Notes

Fixes small issues with the configuration.

## Breaking Change

`CWBlocks.CONFIG.ITEM_NAME` is now a static name which defaults to the `.env` value `ITEM_NAME`. To generate a unique Item name, use the new helper method `getUniqueItemName()` as detailed in [README.MD](README.MD).